### PR TITLE
Add docker_compose default value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@ docker_key_url: https://download.docker.com/linux/ubuntu/gpg
 docker_version: 17.06.2~ce-0~ubuntu
 docker_users:
   - "{{ ansible_user }}"
+docker_compose: false


### PR DESCRIPTION
Adds a default value for the new "docker_compose" variable. Set to false.

This resolves breakages caused by the addition of the new feature in existing playbooks that depend on it, and preserves its behaviour before the change.

Note: 👍 for the addition.